### PR TITLE
Revert "PD-43556 Auto-add cortex.yaml"

### DIFF
--- a/cortex.yaml
+++ b/cortex.yaml
@@ -9,7 +9,7 @@ info:
   x-cortex-tag: go-winio
   x-cortex-type: service
   x-cortex-domain-parents:
-  - tag: endpoint-mavericks
+  - tag: endpoint
 openapi: 3.0.1
 servers:
 - url: "/"


### PR DESCRIPTION
Reverts rapid7/go-winio#4

Currently being marked as owned by the @rapid7/mavericks team, but we don't have any involvement in this codebase.

Seeing from [this pull request](https://github.com/rapid7/go-winio/pull/1) and [this pull request](https://github.com/rapid7/go-winio/pull/2) that it may need to be assigned to the @rapid7/prism team instead.